### PR TITLE
Microsoft.IdentityModel.Protocols.OpenIdConnect to 8.18.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,6 +38,7 @@
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
 
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.21" />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.18.0" />
 
     <PackageVersion Include="McMaster.NETCore.Plugins" Version="2.0.0" />
     <PackageVersion Include="IdentityModel" Version="7.0.0" />

--- a/Http/src/AppCoreNet.Extensions.Http.Authentication.OAuth.OpenIdConnect/AppCoreNet.Extensions.Http.Authentication.OAuth.OpenIdConnect.csproj
+++ b/Http/src/AppCoreNet.Extensions.Http.Authentication.OAuth.OpenIdConnect/AppCoreNet.Extensions.Http.Authentication.OAuth.OpenIdConnect.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Http/src/AppCoreNet.Extensions.Http.Authentication.OAuth.OpenIdConnect/OpenIdConnectOptionsExtensions.cs
+++ b/Http/src/AppCoreNet.Extensions.Http.Authentication.OAuth.OpenIdConnect/OpenIdConnectOptionsExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed under the MIT license.
+// Licensed under the MIT license.
 // Copyright (c) The AppCore .NET project.
 
 using System;
@@ -28,11 +28,7 @@ internal static class OpenIdConnectOptionsExtensions
                 $"Unable to load OpenID configuration for configured scheme: {e.Message}");
         }
 
-        string? tokenRevocationEndpoint = oidcConfig.AdditionalData.TryGetValue(
-            OidcConstants.Discovery.RevocationEndpoint,
-            out object? value)
-            ? value?.ToString()
-            : null;
+        string? tokenRevocationEndpoint = oidcConfig.RevocationEndpoint;
 
         var result = new OAuthClientOptions
         {


### PR DESCRIPTION
Force Microsoft.IdentityModel.Protocols.OpenIdConnect to newer version in

Directory.Packages.props to ensure the compatibility with newewst projects. Can be removed after upgrading the entire solution to .NET 10.